### PR TITLE
fix domain lookups by removing the trailing dots

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 


### PR DESCRIPTION
Zones passed on to libdns from caddy have a trailing dot.  Which does not match the dnsimple api.
```
GET https://api.dnsimple.com/v2/83783/zones/sp5.nl.: 404 Zone `sp5.nl.`
```

Add an unFQDN function similar to https://github.com/libdns/hetzner/blob/4d8da39bef6140105fdef62eadd5b2da319a2d38/provider.go#L71